### PR TITLE
Add useTheme to the ThemingType export

### DIFF
--- a/src/createTheming.js
+++ b/src/createTheming.js
@@ -11,6 +11,7 @@ import type { $DeepShape } from './types';
 export type ThemingType<T> = {
   ThemeProvider: ThemeProviderType<T>,
   withTheme: WithThemeType<T>,
+  useTheme(overrides?: $DeepShape<T>): T,
 };
 
 export default function createTheming<T: Object>(


### PR DESCRIPTION
I copied this line from the Typescript definitions, with a tweak from `$DeepPartial` to `$DeepShape`.

Currently, Flow will yell loudly if you try to use `useTheme` from the result of `createTheming`; with this change, it's happy.